### PR TITLE
Only install mock for running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ depends: depends-ci depends-doc depends-dev
 .PHONY: depends-ci
 depends-ci: env Makefile $(DEPENDS_CI_FLAG)
 $(DEPENDS_CI_FLAG): Makefile
-	$(PIP) install --upgrade pep8 pep257 pylint coverage pytest pytest-describe pytest-expecter pytest-cov pytest-random
+	$(PIP) install --upgrade mock pep8 pep257 pylint coverage pytest pytest-describe pytest-expecter pytest-cov pytest-random
 	@ touch $(DEPENDS_CI_FLAG)  # flag to indicate dependencies are installed
 
 .PHONY: depends-doc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests >= 2.9
-mock >= 2.0
 six >= 1.10.0


### PR DESCRIPTION
Fixes https://github.com/emailage/Emailage_Python/issues/25

Since I got no feedback on my issue I had to make a decision where to install this test requirement. Since everything else needed for running tests is installed from the Makefile I moved the requirement there.