### PR TITLE
chore: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-![alt text](https://www.emailage.com/wp-content/uploads/2018/01/logo-
+> [!WARNING]
+> **This repository will no longer be accessible after 30th September 2026.**
+>
+> This project has been migrated to a consolidated monorepo. Please update your bookmarks, forks,
+> and any CI/CD pipelines to point to the new location:
+>
+> **➡ [https://github.com/lexisnexis-risk-solutions/emailage-public-clients/tree/main/Emailage_Python](https://github.com/lexisnexis-risk-solutions/emailage-public-clients/tree/main/Emailage_Python)**
+>
+> No further updates will be made to this repository.![alt text](https://www.emailage.com/wp-content/uploads/2018/01/logo-
 dark.svg)(https://www.emailage.com)
 
 The Python-language Emailage API client helps companies integrate with our

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 >
 > **➡ [https://github.com/lexisnexis-risk-solutions/emailage-public-clients/tree/main/Emailage_Python](https://github.com/lexisnexis-risk-solutions/emailage-public-clients/tree/main/Emailage_Python)**
 >
-> No further updates will be made to this repository.![alt text](https://www.emailage.com/wp-content/uploads/2018/01/logo-
+> No further updates will be made to this repository.
+
+![alt text](https://www.emailage.com/wp-content/uploads/2018/01/logo-
 dark.svg)(https://www.emailage.com)
 
 The Python-language Emailage API client helps companies integrate with our


### PR DESCRIPTION
## Summary

Adds a deprecation warning banner to the top of the README, notifying users that this repository will cease to be accessible after **30th September 2026** and directing them to the new consolidated monorepo location:

➡ https://github.com/lexisnexis-risk-solutions/emailage-public-clients/tree/main/Emailage_Python

No code changes — README only.